### PR TITLE
Aktualizacja pliku .gitignore o pliki i foldery tworzone przez środowiska programistyczne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,10 @@
 # Build directory
 build
 .cache
+
+# IDE folders
+.vs/
+.idea/
+
+# VS files
+CMakeSettings.json


### PR DESCRIPTION
Korzystanie z tych samych środowisk programistycznych może powodować konflikty wywołane używaniem różnych ustawień bądź wtyczek. Dodanie do pliku .gitignore takich folderów i plików chroni przed takimi konfliktami. Zmianę najlepiej dodać na samym początku życia projektu, aby nie powodowało to kłopotów w przyszłości